### PR TITLE
Generic dental front page with local server

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Windhaven Dental</title>
+    <title>Dental Clinic</title>
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body class="font-sans antialiased leading-normal">
     <header class="bg-white shadow">
       <div class="container mx-auto flex items-center justify-between py-4 px-6">
-        <div class="text-xl font-bold text-blue-700">Windhaven Dental</div>
+        <div class="text-xl font-bold text-blue-700">Dental Clinic</div>
         <nav class="space-x-4 hidden md:flex">
           <a href="#" class="text-gray-600 hover:text-blue-700">Home</a>
           <a href="#about" class="text-gray-600 hover:text-blue-700">About</a>
@@ -32,7 +32,7 @@
 
     <section id="about" class="py-16">
       <div class="container mx-auto px-6">
-        <h2 class="text-3xl font-bold text-center mb-6">Welcome to Windhaven Dental</h2>
+        <h2 class="text-3xl font-bold text-center mb-6">Welcome to Dental Clinic</h2>
         <p class="text-gray-700 text-center max-w-2xl mx-auto">
           Our friendly team is dedicated to creating beautiful smiles. We use the latest dental technology to make your visit as comfortable as possible.
         </p>
@@ -72,7 +72,7 @@
 
     <footer class="bg-blue-900 text-blue-100 py-6">
       <div class="container mx-auto px-6 text-center">
-        <p>&copy; 2024 Windhaven Dental. All rights reserved.</p>
+        <p>&copy; 2024 Dental Clinic. All rights reserved.</p>
       </div>
     </footer>
   </body>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Simple file structure for Tailwind projects",
   "scripts": {
+    "start": "npx serve -s ." ,
     "watch": "npx @tailwindcss/cli -i ./input.css -o ./css/style.css --watch",
     "build": "npx @tailwindcss/cli -i ./input.css -o ./css/style.css"
   },

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,16 @@ npm run watch
 
 This will watch the `src/input.css` file and build it to `css/style.css`, which will be your final CSS file.
 
+## Local development server
+
+To preview the site while working on it, you can start a lightweight static server:
+
+```bash
+npm start
+```
+
+This serves the project locally at <http://localhost:3000> (or the next available port) so you can see your progress in the browser.
+
 ## License
 
 This project is open source and available under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- make the sample landing page generic (no brand names)
- add a simple `npm start` command that serves the site
- update README with instructions for local development

## Testing
- `npm run build`
- `npm start` (verified server started on localhost)

------
https://chatgpt.com/codex/tasks/task_e_687950e0013483309fb15b6a6cc6e0b2